### PR TITLE
fix: add shift-type coloring to calendar days

### DIFF
--- a/templates/miaroSchedule.tmpl
+++ b/templates/miaroSchedule.tmpl
@@ -98,6 +98,10 @@
             box-shadow: 2px 2px 4px var(--shadow-dark), -2px -2px 4px var(--shadow-light);
         }
         body.theme-neumorphism .calendar-day.empty { box-shadow: none; background: transparent; }
+        body.theme-neumorphism .calendar-day.morning { background: rgba(246, 173, 85, 0.15); }
+        body.theme-neumorphism .calendar-day.afternoon { background: rgba(66, 153, 225, 0.15); }
+        body.theme-neumorphism .calendar-day.night { background: rgba(159, 122, 234, 0.15); }
+        body.theme-neumorphism .calendar-day.free { background: rgba(72, 187, 120, 0.1); }
         body.theme-neumorphism .calendar-day.today {
             background: var(--text); color: white;
             box-shadow: 4px 4px 12px rgba(45, 55, 72, 0.3), -4px -4px 8px var(--shadow-light);
@@ -197,6 +201,10 @@
         }
         body.theme-bento .calendar-day:not(.empty):hover { background: #e2e8f0; }
         body.theme-bento .calendar-day.empty { background: transparent; }
+        body.theme-bento .calendar-day.morning { background: rgba(249, 115, 22, 0.12); }
+        body.theme-bento .calendar-day.afternoon { background: rgba(14, 165, 233, 0.12); }
+        body.theme-bento .calendar-day.night { background: rgba(139, 92, 246, 0.12); }
+        body.theme-bento .calendar-day.free { background: rgba(34, 197, 94, 0.08); }
         body.theme-bento .calendar-day.today { background: var(--text); color: white; font-weight: 700; }
         body.theme-bento .calendar-day.next-work { background: var(--accent); color: white; font-weight: 700; box-shadow: 0 4px 16px rgba(99, 102, 241, 0.3); }
         body.theme-bento .day-number { font-weight: 600; }
@@ -282,6 +290,10 @@
         }
         body.theme-terminal .calendar-day:not(.empty):hover { border-color: var(--cyan); }
         body.theme-terminal .calendar-day.empty { background: transparent; border-color: transparent; }
+        body.theme-terminal .calendar-day.morning { border-color: var(--yellow); background: rgba(210, 153, 34, 0.15); }
+        body.theme-terminal .calendar-day.afternoon { border-color: var(--blue); background: rgba(88, 166, 255, 0.15); }
+        body.theme-terminal .calendar-day.night { border-color: var(--purple); background: rgba(163, 113, 247, 0.15); }
+        body.theme-terminal .calendar-day.free { border-color: var(--green); background: rgba(63, 185, 80, 0.08); }
         body.theme-terminal .calendar-day.today { background: var(--green); color: var(--bg); border-color: var(--green); font-weight: 700; }
         body.theme-terminal .calendar-day.next-work { background: var(--cyan); color: var(--bg); border-color: var(--cyan); font-weight: 700; }
         body.theme-terminal .day-number { font-weight: 600; }
@@ -588,7 +600,7 @@
                     <div class="calendar-day-header">Sam</div>
                     <div class="calendar-day-header">Dim</div>
                     {{ range .CalendarDays }}
-                    <div class="calendar-day {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+                    <div class="calendar-day {{ .ShiftClass }} {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
                         {{ if not .IsEmpty }}
                         <div class="day-number">{{ .DayNumber }}</div>
                         <div class="shift-indicator">{{ .ShiftType }}</div>
@@ -678,7 +690,7 @@
                         <div class="calendar-header">Sam</div>
                         <div class="calendar-header">Dim</div>
                         {{ range .CalendarDays }}
-                        <div class="calendar-day {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+                        <div class="calendar-day {{ .ShiftClass }} {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
                             {{ if not .IsEmpty }}
                             <div class="day-number">{{ .DayNumber }}</div>
                             <div class="shift-indicator">{{ .ShiftType }}</div>
@@ -779,7 +791,7 @@
                         <div class="calendar-header">SAM</div>
                         <div class="calendar-header">DIM</div>
                         {{ range .CalendarDays }}
-                        <div class="calendar-day {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+                        <div class="calendar-day {{ .ShiftClass }} {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
                             {{ if not .IsEmpty }}
                             <div class="day-number">{{ .DayNumber }}</div>
                             <div class="shift-indicator">{{ .ShiftType }}</div>


### PR DESCRIPTION
## Summary
- The `ShiftClass` field was populated in Go (`pkg/template.go`) but never rendered in the HTML template, so calendar days had no shift-type colors
- Added `{{ .ShiftClass }}` to the calendar day class attribute in all 3 themes (Neumorphism, Bento, Terminal)
- Added per-theme CSS background rules for `.calendar-day.morning/afternoon/night/free` with subtle tints

## Test plan
- [x] `go test ./...` passes
- [x] Verified rendered HTML includes shift classes (`morning`, `afternoon`, `night`, `free`)
- [x] Verified `today` and `next-work` classes still render alongside shift classes
- [ ] Visual check on all 3 themes via Tailscale