### PR TITLE
feat: add month navigation to calendar

### DIFF
--- a/docs/superpowers/plans/2026-03-28-month-navigation.md
+++ b/docs/superpowers/plans/2026-03-28-month-navigation.md
@@ -1,0 +1,775 @@
+# Month Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add month navigation to the calendar so users can browse past and future months, with full-week grids showing adjacent-month days.
+
+**Architecture:** Add `?month=YYYY-MM` query param to the HTML handler. Refactor `GenerateCalendarData` to accept a target month and fill leading/trailing days from adjacent months. Add prev/next navigation arrows to the calendar header in all 3 themes.
+
+**Tech Stack:** Go/Gin, HTML/CSS templates, Playwright for browser testing
+
+**Spec:** `docs/superpowers/specs/2026-03-28-month-navigation-design.md`
+
+---
+
+### Task 1: Update CalendarDay struct and GenerateCalendarData
+
+**Files:**
+- Modify: `pkg/template.go:17-25` (CalendarDay struct)
+- Modify: `pkg/template.go:8-15` (ScheduleBeautified struct)
+- Modify: `pkg/template.go:104-163` (GenerateCalendarData function)
+- Modify: `pkg/template.go:30-46` (FormatScheduleBeautified function)
+- Test: `pkg/template_test.go`
+
+- [ ] **Step 1: Write failing test for GenerateCalendarData with full weeks**
+
+Add to `pkg/template_test.go`:
+
+```go
+func TestGenerateCalendarData_FullWeeks(t *testing.T) {
+	// March 2026: starts on Sunday, ends on Tuesday
+	// Week 1 should have Mon Feb 23 - Sat Feb 28 as other-month days
+	// Last week should have Wed Apr 1 - Sun Apr 5 as other-month days
+	now := time.Date(2026, time.March, 15, 12, 0, 0, 0, parisLoc)
+	targetMonth := time.Date(2026, time.March, 1, 0, 0, 0, 0, parisLoc)
+	schedule := CalculateSchedule(now, MiaroTeam)
+
+	days := GenerateCalendarData(schedule, targetMonth, 1)
+
+	// Grid should be 5 weeks * 7 = 35 days
+	assert.Equal(t, 35, len(days))
+
+	// First day should be Monday Feb 23 (other-month)
+	assert.Equal(t, 23, days[0].DayNumber)
+	assert.Equal(t, true, days[0].IsOtherMonth)
+	assert.NotEqual(t, "", days[0].ShiftClass)
+
+	// 7th day should be Sunday March 1 (this month)
+	assert.Equal(t, 1, days[6].DayNumber)
+	assert.Equal(t, false, days[6].IsOtherMonth)
+
+	// Day 15 should be marked as today
+	// Feb has 6 leading days, so March 15 is at index 6+14 = 20
+	assert.Equal(t, 15, days[20].DayNumber)
+	assert.Equal(t, true, days[20].IsToday)
+
+	// Last day should be Sunday Apr 5 (other-month)
+	assert.Equal(t, 5, days[34].DayNumber)
+	assert.Equal(t, true, days[34].IsOtherMonth)
+}
+
+func TestGenerateCalendarData_OtherMonthNoToday(t *testing.T) {
+	// Viewing April 2026 while today is March 15 -- no day should be IsToday
+	now := time.Date(2026, time.March, 15, 12, 0, 0, 0, parisLoc)
+	targetMonth := time.Date(2026, time.April, 1, 0, 0, 0, 0, parisLoc)
+	schedule := CalculateSchedule(now, MiaroTeam)
+
+	days := GenerateCalendarData(schedule, targetMonth, 1)
+
+	for _, day := range days {
+		if day.IsToday {
+			t.Errorf("No day should be IsToday when viewing a different month, but day %d is", day.DayNumber)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -v -run TestGenerateCalendarData_FullWeeks ./pkg/`
+Expected: FAIL -- wrong number of arguments to `GenerateCalendarData`
+
+- [ ] **Step 3: Update CalendarDay struct**
+
+In `pkg/template.go`, replace the `CalendarDay` struct:
+
+```go
+// CalendarDay represents a single day in the calendar view
+type CalendarDay struct {
+	DayNumber    int    // Day of the month (1-31)
+	ShiftType    string // "Matin", "Après-midi", "Nuit", "Libre"
+	IsToday      bool   // True if this is today
+	IsNextWork   bool   // True if this is the next working day
+	IsOtherMonth bool   // True for days from adjacent months
+	ShiftClass   string // CSS class: "morning", "afternoon", "night", "free"
+}
+```
+
+- [ ] **Step 4: Update ScheduleBeautified struct**
+
+In `pkg/template.go`, replace the `ScheduleBeautified` struct:
+
+```go
+type ScheduleBeautified struct {
+	Schedule               string        // e.g., "du matin", "de l'après-midi", "de nuit", "libre"
+	IsWorking              string        // e.g., "est au travail", "n'est pas au travail"
+	ScheduleNextWorkingDay string        // e.g., "du matin" (for the next working day)
+	NextWorkingDay         string        // e.g., "demain", "dans 3 jours"
+	CalendarDays           []CalendarDay // Calendar data for the month
+	CalendarMonthLabel     string        // e.g., "Mars 2026"
+	PrevMonth              string        // e.g., "2026-02" for prev link
+	NextMonth              string        // e.g., "2026-04" for next link
+	IsCurrentMonth         bool          // True when viewing current month
+}
+```
+
+- [ ] **Step 5: Add French month names helper**
+
+In `pkg/template.go`, add after the struct definitions:
+
+```go
+var frenchMonths = map[time.Month]string{
+	time.January:   "Janvier",
+	time.February:  "Février",
+	time.March:     "Mars",
+	time.April:     "Avril",
+	time.May:       "Mai",
+	time.June:      "Juin",
+	time.July:      "Juillet",
+	time.August:    "Août",
+	time.September: "Septembre",
+	time.October:   "Octobre",
+	time.November:  "Novembre",
+	time.December:  "Décembre",
+}
+```
+
+- [ ] **Step 6: Rewrite GenerateCalendarData**
+
+Replace `GenerateCalendarData` in `pkg/template.go`:
+
+```go
+// GenerateCalendarData generates calendar data for the target month with full weeks.
+// Leading/trailing days from adjacent months are included with IsOtherMonth=true.
+func GenerateCalendarData(currentSchedule Schedule, targetMonth time.Time, nextWorkDays int) []CalendarDay {
+	now := currentSchedule.TimeRequested.In(parisLoc)
+	targetMonth = targetMonth.In(parisLoc)
+
+	year, month, _ := targetMonth.Date()
+	firstDay := time.Date(year, month, 1, 0, 0, 0, 0, parisLoc)
+	lastDay := firstDay.AddDate(0, 1, -1)
+
+	isCurrentMonth := now.Year() == year && now.Month() == month
+
+	// Monday = 0, Sunday = 6
+	weekdayOffset := int(firstDay.Weekday()) - 1
+	if weekdayOffset == -1 {
+		weekdayOffset = 6
+	}
+
+	var calendarDays []CalendarDay
+
+	// Leading days from previous month
+	for i := weekdayOffset; i > 0; i-- {
+		d := firstDay.AddDate(0, 0, -i)
+		calendarDays = append(calendarDays, buildCalendarDay(d, currentSchedule.Team, now, isCurrentMonth, nextWorkDays, true))
+	}
+
+	// Days of the target month
+	for day := 1; day <= lastDay.Day(); day++ {
+		d := time.Date(year, month, day, 12, 0, 0, 0, parisLoc)
+		calendarDays = append(calendarDays, buildCalendarDay(d, currentSchedule.Team, now, isCurrentMonth, nextWorkDays, false))
+	}
+
+	// Trailing days from next month
+	trailingDays := 7 - (len(calendarDays) % 7)
+	if trailingDays < 7 {
+		for i := 1; i <= trailingDays; i++ {
+			d := lastDay.AddDate(0, 0, i)
+			calendarDays = append(calendarDays, buildCalendarDay(d, currentSchedule.Team, now, isCurrentMonth, nextWorkDays, true))
+		}
+	}
+
+	return calendarDays
+}
+
+func buildCalendarDay(date time.Time, team int, now time.Time, isCurrentMonth bool, nextWorkDays int, isOtherMonth bool) CalendarDay {
+	daySchedule := CalculateSchedule(date, team)
+	_, _, day := date.Date()
+
+	isToday := false
+	isNextWork := false
+	if isCurrentMonth && !isOtherMonth {
+		isToday = day == now.Day()
+		isNextWork = !isToday && daySchedule.ScheduleType != FREE &&
+			(date.After(now) || date.Equal(now)) &&
+			day == now.Day()+nextWorkDays
+	}
+
+	var shiftType, shiftClass string
+	switch daySchedule.ScheduleType {
+	case MORNING:
+		shiftType = "Matin"
+		shiftClass = "morning"
+	case AFTERNOON:
+		shiftType = "Après-midi"
+		shiftClass = "afternoon"
+	case NIGHT:
+		shiftType = "Nuit"
+		shiftClass = "night"
+	case FREE:
+		shiftType = "Libre"
+		shiftClass = "free"
+	}
+
+	return CalendarDay{
+		DayNumber:    day,
+		ShiftType:    shiftType,
+		IsToday:      isToday,
+		IsNextWork:   isNextWork,
+		IsOtherMonth: isOtherMonth,
+		ShiftClass:   shiftClass,
+	}
+}
+```
+
+- [ ] **Step 7: Update FormatScheduleBeautified**
+
+Replace `FormatScheduleBeautified` in `pkg/template.go`:
+
+```go
+func FormatScheduleBeautified(schedule Schedule, targetMonth time.Time) ScheduleBeautified {
+	currentDay := getBeautifiedSchedule(schedule.ScheduleType)
+	isWorking := isWorkingString(schedule)
+	scheduleNextWorkingDay, nextWorkingDay, nextWorkDays := nextWorkingDay(schedule.DayInSchedule)
+
+	calendarDays := GenerateCalendarData(schedule, targetMonth, nextWorkDays)
+
+	now := schedule.TimeRequested.In(parisLoc)
+	year, month, _ := targetMonth.In(parisLoc).Date()
+
+	prevMonth := targetMonth.AddDate(0, -1, 0)
+	nextMonthDate := targetMonth.AddDate(0, 1, 0)
+
+	return ScheduleBeautified{
+		Schedule:               currentDay,
+		IsWorking:              isWorking,
+		ScheduleNextWorkingDay: scheduleNextWorkingDay,
+		NextWorkingDay:         nextWorkingDay,
+		CalendarDays:           calendarDays,
+		CalendarMonthLabel:     fmt.Sprintf("%s %d", frenchMonths[month], year),
+		PrevMonth:              prevMonth.Format("2006-01"),
+		NextMonth:              nextMonthDate.Format("2006-01"),
+		IsCurrentMonth:         now.Year() == year && now.Month() == month,
+	}
+}
+```
+
+- [ ] **Step 8: Fix any references to IsEmpty in template.go**
+
+Search for `IsEmpty` in `pkg/template.go` and remove any remaining references. The old empty-cell loop in `GenerateCalendarData` is already gone from the rewrite above.
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `go test -v -run TestGenerateCalendarData ./pkg/`
+Expected: PASS for both `TestGenerateCalendarData_FullWeeks` and `TestGenerateCalendarData_OtherMonthNoToday`
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add pkg/template.go pkg/template_test.go
+git commit -m "feat: add full-week calendar grid with month navigation data model"
+```
+
+---
+
+### Task 2: Update handler to parse ?month= and pass new data
+
+**Files:**
+- Modify: `main.go:62-75` (renderSchedule function)
+- Test: `main_test.go`
+
+- [ ] **Step 1: Write failing tests for month param**
+
+Add to `main_test.go`:
+
+```go
+func TestSchedulerHandler_MonthParam(t *testing.T) {
+	router := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?month=2026-04", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Avril 2026") {
+		t.Error("Expected response to contain 'Avril 2026' for month=2026-04")
+	}
+}
+
+func TestSchedulerHandler_InvalidMonthDefaultsToCurrent(t *testing.T) {
+	router := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?month=invalid", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestSchedulerHandler_MonthAndTeamParams(t *testing.T) {
+	router := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?month=2026-05&team=3", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Mai 2026") {
+		t.Error("Expected response to contain 'Mai 2026'")
+	}
+
+	// Check cookie was set for team
+	cookies := w.Result().Cookies()
+	var teamCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "miaro-team" {
+			teamCookie = c
+		}
+	}
+	if teamCookie == nil {
+		t.Fatal("Expected miaro-team cookie to be set")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -v -run TestSchedulerHandler_MonthParam -run TestSchedulerHandler_InvalidMonth -run TestSchedulerHandler_MonthAndTeam .`
+Expected: FAIL -- compilation errors since `FormatScheduleBeautified` signature changed
+
+- [ ] **Step 3: Add month parsing helper to main.go**
+
+Add to `main.go` near the other parse helpers:
+
+```go
+func parseMonthParam(c *gin.Context) time.Time {
+	monthStr := c.Query("month")
+	if monthStr != "" {
+		t, err := time.Parse("2006-01", monthStr)
+		if err == nil {
+			return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+		}
+	}
+	now := time.Now().In(pkg.ParisLoc())
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+```
+
+- [ ] **Step 4: Expose parisLoc from pkg**
+
+Add to `pkg/schedulerService.go`:
+
+```go
+// ParisLoc returns the Europe/Paris timezone location.
+func ParisLoc() *time.Location {
+	return parisLoc
+}
+```
+
+- [ ] **Step 5: Update renderSchedule to pass month and new template data**
+
+Replace `renderSchedule` in `main.go`:
+
+```go
+func renderSchedule(c *gin.Context, team int) {
+	schedule := pkg.CalculateSchedule(time.Now(), team)
+	targetMonth := parseMonthParam(c)
+	scheduleBeautified := pkg.FormatScheduleBeautified(schedule, targetMonth)
+
+	// Build month nav query string preserving team param
+	monthQuery := ""
+	if team > 1 {
+		monthQuery = fmt.Sprintf("&team=%d", team)
+	}
+
+	c.HTML(http.StatusOK, "miaroSchedule.tmpl", gin.H{
+		"Schedule":               scheduleBeautified.Schedule,
+		"IsWorking":              scheduleBeautified.IsWorking,
+		"NextWorkingDay":         scheduleBeautified.NextWorkingDay,
+		"ScheduleNextWorkingDay": scheduleBeautified.ScheduleNextWorkingDay,
+		"CalendarDays":           scheduleBeautified.CalendarDays,
+		"CalendarMonthLabel":     scheduleBeautified.CalendarMonthLabel,
+		"PrevMonth":              scheduleBeautified.PrevMonth,
+		"NextMonth":              scheduleBeautified.NextMonth,
+		"IsCurrentMonth":         scheduleBeautified.IsCurrentMonth,
+		"MonthQuery":             monthQuery,
+		"Team":                   team,
+		"Teams":                  pkg.BuildTeamList(team),
+	})
+}
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test -v ./... `
+Expected: PASS -- all existing and new tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add main.go main_test.go pkg/schedulerService.go
+git commit -m "feat: parse ?month= param and pass calendar nav data to template"
+```
+
+---
+
+### Task 3: Update template -- navigation header and other-month styling
+
+**Files:**
+- Modify: `templates/miaroSchedule.tmpl` (CSS + HTML for all 3 themes)
+
+This task uses the **frontend-design** skill for UI implementation.
+
+- [ ] **Step 1: Add other-month CSS rules for neumorphism theme**
+
+After the `.calendar-day.free` rule (around line 105), add:
+
+```css
+body.theme-neumorphism .calendar-day.other-month { opacity: 0.35; pointer-events: none; }
+body.theme-neumorphism .calendar-day.other-month.today,
+body.theme-neumorphism .calendar-day.other-month.next-work { opacity: 0.35; }
+```
+
+Replace the `.calendar-day.empty` rule:
+```css
+/* Remove: body.theme-neumorphism .calendar-day.empty { box-shadow: none; background: transparent; } */
+```
+
+Add nav arrow styles after the `.calendar-header` styles:
+
+```css
+body.theme-neumorphism .calendar-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+body.theme-neumorphism .calendar-nav h2 { font-size: 1.125rem; font-weight: 700; }
+body.theme-neumorphism .calendar-nav a {
+    width: 36px; height: 36px; display: flex; align-items: center; justify-content: center;
+    border-radius: 50%; color: var(--text); text-decoration: none; font-size: 1.125rem;
+    background: var(--bg);
+    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    transition: all 0.2s;
+}
+body.theme-neumorphism .calendar-nav a:hover {
+    box-shadow: 1px 1px 3px var(--shadow-dark), -1px -1px 3px var(--shadow-light);
+}
+```
+
+- [ ] **Step 2: Add other-month CSS rules for bento theme**
+
+After the `.calendar-day.free` rule in bento section, add:
+
+```css
+body.theme-bento .calendar-day.other-month { opacity: 0.35; pointer-events: none; }
+```
+
+Remove the `.calendar-day.empty` rule for bento.
+
+Add nav styles:
+
+```css
+body.theme-bento .calendar-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+body.theme-bento .calendar-nav h2 { font-size: 1rem; font-weight: 600; }
+body.theme-bento .calendar-nav a {
+    width: 32px; height: 32px; display: flex; align-items: center; justify-content: center;
+    border-radius: 10px; color: var(--text); text-decoration: none; font-size: 1rem;
+    background: var(--bg); border: 1px solid var(--border); transition: all 0.15s;
+}
+body.theme-bento .calendar-nav a:hover { background: #e2e8f0; }
+```
+
+- [ ] **Step 3: Add other-month CSS rules for terminal theme**
+
+After the `.calendar-day.free` rule in terminal section, add:
+
+```css
+body.theme-terminal .calendar-day.other-month { opacity: 0.3; pointer-events: none; }
+```
+
+Remove the `.calendar-day.empty` rule for terminal.
+
+Add nav styles:
+
+```css
+body.theme-terminal .calendar-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+body.theme-terminal .calendar-nav span { color: var(--cyan); font-weight: 600; }
+body.theme-terminal .calendar-nav a { color: var(--green); text-decoration: none; font-size: 0.875rem; }
+body.theme-terminal .calendar-nav a:hover { text-decoration: underline; }
+```
+
+- [ ] **Step 4: Update neumorphism calendar header HTML**
+
+Replace the neumorphism calendar header (around line 590-593):
+
+```html
+<div class="calendar-nav">
+    <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">&larr;</a>
+    <h2>{{ .CalendarMonthLabel }}</h2>
+    <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">&rarr;</a>
+</div>
+```
+
+- [ ] **Step 5: Update neumorphism calendar day classes**
+
+Replace the calendar day div class in neumorphism (around line 595):
+
+```html
+<div class="calendar-day {{ .ShiftClass }} {{ if .IsOtherMonth }}other-month{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+    {{ if not .IsOtherMonth }}
+    <div class="day-number">{{ .DayNumber }}</div>
+    <div class="shift-indicator">{{ .ShiftType }}</div>
+    {{ else }}
+    <div class="day-number">{{ .DayNumber }}</div>
+    {{ end }}
+</div>
+```
+
+- [ ] **Step 6: Update bento calendar header HTML**
+
+Replace the bento calendar title section (around line 680-683):
+
+```html
+<div class="calendar-nav">
+    <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">&larr;</a>
+    <h2>{{ .CalendarMonthLabel }}</h2>
+    <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">&rarr;</a>
+</div>
+```
+
+- [ ] **Step 7: Update bento calendar day classes**
+
+Replace the calendar day div class in bento (around line 690):
+
+```html
+<div class="calendar-day {{ .ShiftClass }} {{ if .IsOtherMonth }}other-month{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+    {{ if not .IsOtherMonth }}
+    <div class="day-number">{{ .DayNumber }}</div>
+    <div class="shift-indicator">{{ .ShiftType }}</div>
+    {{ else }}
+    <div class="day-number">{{ .DayNumber }}</div>
+    {{ end }}
+</div>
+```
+
+- [ ] **Step 8: Update terminal calendar header HTML**
+
+Replace the terminal section title (around line 785):
+
+```html
+<div class="calendar-nav">
+    <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">[prev]</a>
+    <span>$ cal --schedule {{ .CalendarMonthLabel }}</span>
+    <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">[next]</a>
+</div>
+```
+
+- [ ] **Step 9: Update terminal calendar day classes**
+
+Replace the calendar day div class in terminal (around line 795):
+
+```html
+<div class="calendar-day {{ .ShiftClass }} {{ if .IsOtherMonth }}other-month{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+    {{ if not .IsOtherMonth }}
+    <div class="day-number">{{ .DayNumber }}</div>
+    <div class="shift-indicator">{{ .ShiftType }}</div>
+    {{ else }}
+    <div class="day-number">{{ .DayNumber }}</div>
+    {{ end }}
+</div>
+```
+
+- [ ] **Step 10: Remove all IsEmpty references from template**
+
+Search the template for `IsEmpty` and `empty` class references. Remove:
+- All `{{ if .IsEmpty }}empty{{ end }}` from calendar day classes
+- The `{{ if not .IsEmpty }}` conditionals (replaced by `{{ if not .IsOtherMonth }}` above)
+- CSS rules for `.calendar-day.empty` in all three themes
+
+- [ ] **Step 11: Update selectTeam JavaScript to preserve month param**
+
+In the JavaScript section (around line 830), update `selectTeam`:
+
+```javascript
+function selectTeam(teamNum) {
+    const url = new URL(window.location);
+    if (teamNum === '1' || teamNum === 1) {
+        url.searchParams.delete('team');
+    } else {
+        url.searchParams.set('team', teamNum);
+    }
+    window.location.href = url.pathname + '?' + url.searchParams.toString();
+}
+```
+
+- [ ] **Step 12: Run build and all tests**
+
+Run: `go build -o /dev/null . && go test -v ./...`
+Expected: PASS -- build succeeds, all tests pass
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add templates/miaroSchedule.tmpl
+git commit -m "feat: add month navigation UI with full-week grid and other-month styling"
+```
+
+---
+
+### Task 4: Update existing tests for new signatures
+
+**Files:**
+- Modify: `main_test.go` (fix any broken assertions)
+- Modify: `pkg/template_test.go` (fix any broken assertions)
+
+- [ ] **Step 1: Check for broken tests from IsEmpty removal**
+
+Run: `go test -v ./...`
+
+If there are failures related to `IsEmpty`, update test assertions to use `IsOtherMonth` instead.
+
+- [ ] **Step 2: Update TestSchedulerHandler expected strings**
+
+In `main_test.go`, the test `TestSchedulerHandler` checks for `"Planning du mois"`. This header text is now replaced by the dynamic month label. Update:
+
+```go
+expectedStrings := []string{
+    "<!DOCTYPE html>",
+    "Horaire de Miaro",
+    "Statut",
+}
+```
+
+The month label is dynamic so don't assert on a fixed string.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `go test -v ./...`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main_test.go pkg/template_test.go
+git commit -m "test: update tests for month navigation changes"
+```
+
+---
+
+### Task 5: Visual testing with Playwright
+
+**Files:**
+- Test files in `/tmp/` (Playwright convention)
+
+This task uses the **playwright-skill** for browser testing across all 3 themes.
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+PORT=8099 go run . &
+```
+
+- [ ] **Step 2: Test neumorphism theme -- current month**
+
+Navigate to `http://localhost:8099/miaro`. Verify:
+- Calendar shows current month label (e.g., "Mars 2026")
+- Prev/next arrows are visible
+- Today is highlighted
+- Other-month days are greyed out with day numbers
+- Shift colors are visible on all days
+
+Take a screenshot.
+
+- [ ] **Step 3: Test month navigation -- next month**
+
+Click the next arrow (or navigate to `?month=2026-04`). Verify:
+- Calendar shows "Avril 2026"
+- No day is highlighted as today
+- Other-month days fill the first and last rows
+- Shift colors are visible
+
+Take a screenshot.
+
+- [ ] **Step 4: Test month navigation -- previous month**
+
+Click the prev arrow. Verify it returns to the current month. Click prev again for February. Verify:
+- Calendar shows "Février 2026"
+- Correct number of days (28)
+- Full weeks rendered
+
+- [ ] **Step 5: Test with team param preserved**
+
+Navigate to `http://localhost:8099/miaro?team=3&month=2026-05`. Verify:
+- Calendar shows "Mai 2026"
+- Team 3 is selected in dropdown
+- Clicking prev/next preserves team=3 in the URL
+
+- [ ] **Step 6: Test bento theme**
+
+Switch to Bento theme. Verify:
+- Navigation arrows styled correctly
+- Other-month days greyed out
+- Shift colors visible
+
+Take a screenshot.
+
+- [ ] **Step 7: Test terminal theme**
+
+Switch to Terminal theme. Verify:
+- `[prev]` and `[next]` links styled correctly
+- Header shows `$ cal --schedule Mars 2026`
+- Other-month days greyed out
+
+Take a screenshot.
+
+- [ ] **Step 8: Test mobile viewport**
+
+Resize to 375px width. Verify:
+- Calendar grid still fits
+- Navigation arrows accessible
+- No horizontal scrolling
+
+- [ ] **Step 9: Stop dev server**
+
+```bash
+kill %1 2>/dev/null
+```
+
+---
+
+### Task 6: Final cleanup and commit
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+go test -v -race ./...
+```
+
+Expected: PASS with no race conditions
+
+- [ ] **Step 2: Format code**
+
+```bash
+go fmt ./...
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+go build -o /dev/null .
+```
+
+- [ ] **Step 4: Review changes**
+
+```bash
+git diff main --stat
+```
+
+Verify only expected files changed.

--- a/docs/superpowers/specs/2026-03-28-month-navigation-design.md
+++ b/docs/superpowers/specs/2026-03-28-month-navigation-design.md
@@ -1,0 +1,108 @@
+# Month Navigation Design
+
+Add month navigation to the calendar view so users can browse past and future months.
+
+## Current Behavior
+
+- Calendar shows the current month only
+- Leading days before the 1st are empty cells
+- No trailing days after the last day of the month
+- No way to view other months
+
+## New Behavior
+
+### Query Parameter
+
+`?month=YYYY-MM` selects which month to display. Missing or invalid defaults to current month. Combines with existing `?team=N` param.
+
+Examples:
+- `/miaro` -- current month, default team
+- `/miaro?month=2026-04` -- April 2026, default team
+- `/miaro?month=2026-04&team=3` -- April 2026, team 3
+
+### Full-Week Calendar Grid
+
+Instead of empty cells at the start/end of the month, show actual dates from adjacent months:
+
+- **Leading days**: If March 1 is a Sunday, show Mon Feb 23 through Sat Feb 28 before it, greyed out with their shift types
+- **Trailing days**: If March 31 is a Tuesday, show Wed Apr 1 through Sun Apr 5 after it, greyed out with their shift types
+
+Adjacent-month days get shift coloring (faint) but are visually distinct via reduced opacity.
+
+### Navigation Header
+
+Replace the static month/year header with `< Mars 2026 >` where `<` and `>` are clickable links:
+
+- `<` links to `?month=2026-02` (preserving `?team=` if set)
+- `>` links to `?month=2026-04` (preserving `?team=` if set)
+- No bounds -- schedule is deterministic for any date
+- Month name in French (existing `title` template function)
+
+### Status Cards Unchanged
+
+The shift status, working status, and next-working-day cards always reflect **today** regardless of which month the calendar shows. Only the calendar grid changes.
+
+## Data Model Changes
+
+### CalendarDay struct
+
+Add field:
+- `IsOtherMonth bool` -- true for leading/trailing days from adjacent months
+
+Remove field:
+- `IsEmpty bool` -- no longer needed (replaced by `IsOtherMonth`)
+
+### ScheduleBeautified struct
+
+Add fields:
+- `CalendarMonthLabel string` -- display label, e.g. "Mars 2026"
+- `PrevMonth string` -- `YYYY-MM` for prev link
+- `NextMonth string` -- `YYYY-MM` for next link
+- `IsCurrentMonth bool` -- true when viewing the current month
+
+### GenerateCalendarData changes
+
+New signature: accept an explicit `targetMonth time.Time` parameter instead of deriving from `schedule.TimeRequested`.
+
+Logic:
+1. Compute first/last day of target month
+2. Fill leading days from previous month (actual dates, `IsOtherMonth: true`)
+3. Fill days of the month (as today, with `IsToday`/`IsNextWork` only when `IsCurrentMonth`)
+4. Fill trailing days from next month to complete the last week row
+
+### Handler changes (main.go)
+
+1. Parse `?month=YYYY-MM` from query string
+2. Validate format; default to current month on invalid/missing
+3. Compute `targetMonth` as first-of-month in `parisLoc`
+4. Pass `targetMonth` to calendar generation
+5. Compute `CalendarMonthLabel`, `PrevMonth`, `NextMonth`
+6. Pass all new fields to template data
+
+## Template Changes
+
+All 3 themes (neumorphism, bento, terminal):
+
+1. Calendar header: replace static text with `< {{ .CalendarMonthLabel }} >` navigation
+2. Calendar day: add `{{ if .IsOtherMonth }}other-month{{ end }}` class
+3. Remove `{{ if .IsEmpty }}empty{{ end }}` class usage (replaced by `IsOtherMonth`)
+
+## CSS Changes
+
+All 3 themes:
+
+1. `.calendar-day.other-month` -- reduced opacity (~0.35-0.4), no hover effects
+2. Remove `.calendar-day.empty` rules (replace with `.other-month`)
+3. Navigation arrows: styled per-theme as subtle clickable elements
+
+## JSON Endpoint
+
+`/miaro/json` does not include calendar data today and is not affected.
+
+## Testing
+
+- Unit test `GenerateCalendarData` with a known month to verify leading/trailing days are correct
+- Test `?month=` param parsing (valid, invalid, missing)
+- Test that `IsOtherMonth` days have correct shift types
+- Test month label and prev/next values
+- Integration test that the HTML contains nav links

--- a/main.go
+++ b/main.go
@@ -76,10 +76,12 @@ func renderSchedule(c *gin.Context, team int) {
 	targetMonth := parseMonthParam(c)
 	scheduleBeautified := pkg.FormatScheduleBeautified(schedule, targetMonth)
 
-	// Build month nav query string preserving team param
-	monthQuery := ""
+	// Build full month nav URLs preserving team param
+	prevMonthURL := fmt.Sprintf("/miaro?month=%s", scheduleBeautified.PrevMonth)
+	nextMonthURL := fmt.Sprintf("/miaro?month=%s", scheduleBeautified.NextMonth)
 	if team > 1 {
-		monthQuery = fmt.Sprintf("&team=%d", team)
+		prevMonthURL = fmt.Sprintf("/miaro?month=%s&team=%d", scheduleBeautified.PrevMonth, team)
+		nextMonthURL = fmt.Sprintf("/miaro?month=%s&team=%d", scheduleBeautified.NextMonth, team)
 	}
 
 	c.HTML(http.StatusOK, "miaroSchedule.tmpl", gin.H{
@@ -89,10 +91,9 @@ func renderSchedule(c *gin.Context, team int) {
 		"ScheduleNextWorkingDay": scheduleBeautified.ScheduleNextWorkingDay,
 		"CalendarDays":           scheduleBeautified.CalendarDays,
 		"CalendarMonthLabel":     scheduleBeautified.CalendarMonthLabel,
-		"PrevMonth":              scheduleBeautified.PrevMonth,
-		"NextMonth":              scheduleBeautified.NextMonth,
+		"PrevMonthURL":           template.URL(prevMonthURL),
+		"NextMonthURL":           template.URL(nextMonthURL),
 		"IsCurrentMonth":         scheduleBeautified.IsCurrentMonth,
-		"MonthQuery":             monthQuery,
 		"Team":                   team,
 		"Teams":                  pkg.BuildTeamList(team),
 	})

--- a/main.go
+++ b/main.go
@@ -59,9 +59,28 @@ func setTeamCookie(c *gin.Context, team int) {
 	})
 }
 
+func parseMonthParam(c *gin.Context) time.Time {
+	monthStr := c.Query("month")
+	if monthStr != "" {
+		t, err := time.Parse("2006-01", monthStr)
+		if err == nil {
+			return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+		}
+	}
+	now := time.Now().In(pkg.ParisLoc())
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
 func renderSchedule(c *gin.Context, team int) {
 	schedule := pkg.CalculateSchedule(time.Now(), team)
-	scheduleBeautified := pkg.FormatScheduleBeautified(schedule)
+	targetMonth := parseMonthParam(c)
+	scheduleBeautified := pkg.FormatScheduleBeautified(schedule, targetMonth)
+
+	// Build month nav query string preserving team param
+	monthQuery := ""
+	if team > 1 {
+		monthQuery = fmt.Sprintf("&team=%d", team)
+	}
 
 	c.HTML(http.StatusOK, "miaroSchedule.tmpl", gin.H{
 		"Schedule":               scheduleBeautified.Schedule,
@@ -69,6 +88,11 @@ func renderSchedule(c *gin.Context, team int) {
 		"NextWorkingDay":         scheduleBeautified.NextWorkingDay,
 		"ScheduleNextWorkingDay": scheduleBeautified.ScheduleNextWorkingDay,
 		"CalendarDays":           scheduleBeautified.CalendarDays,
+		"CalendarMonthLabel":     scheduleBeautified.CalendarMonthLabel,
+		"PrevMonth":              scheduleBeautified.PrevMonth,
+		"NextMonth":              scheduleBeautified.NextMonth,
+		"IsCurrentMonth":         scheduleBeautified.IsCurrentMonth,
+		"MonthQuery":             monthQuery,
 		"Team":                   team,
 		"Teams":                  pkg.BuildTeamList(team),
 	})
@@ -80,10 +104,14 @@ func SchedulerHandler() gin.HandlerFunc {
 		teamParam, hasValidParam := parseTeamParam(c)
 		teamCookie, hasValidCookie := readTeamCookie(c)
 
-		// Canonicalize: ?team=1 -> redirect to /miaro
+		// Canonicalize: ?team=1 -> redirect to /miaro (preserve month)
 		if hasValidParam && teamParam == pkg.MiaroTeam {
 			setTeamCookie(c, pkg.MiaroTeam)
-			c.Redirect(http.StatusFound, "/miaro")
+			redirect := "/miaro"
+			if m := c.Query("month"); m != "" {
+				redirect = fmt.Sprintf("/miaro?month=%s", m)
+			}
+			c.Redirect(http.StatusFound, redirect)
 			return
 		}
 
@@ -94,9 +122,13 @@ func SchedulerHandler() gin.HandlerFunc {
 			return
 		}
 
-		// No valid param — check cookie
+		// No valid param — check cookie (preserve month)
 		if hasValidCookie && teamCookie != pkg.MiaroTeam {
-			c.Redirect(http.StatusFound, fmt.Sprintf("/miaro?team=%d", teamCookie))
+			redirect := fmt.Sprintf("/miaro?team=%d", teamCookie)
+			if m := c.Query("month"); m != "" {
+				redirect = fmt.Sprintf("/miaro?team=%d&month=%s", teamCookie, m)
+			}
+			c.Redirect(http.StatusFound, redirect)
 			return
 		}
 
@@ -115,7 +147,9 @@ func SchedulerJSONHandler() gin.HandlerFunc {
 		}
 
 		schedule := pkg.CalculateSchedule(time.Now(), team)
-		scheduleBeautified := pkg.FormatScheduleBeautified(schedule)
+		now := time.Now().In(pkg.ParisLoc())
+		currentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		scheduleBeautified := pkg.FormatScheduleBeautified(schedule, currentMonth)
 
 		c.JSON(http.StatusOK, gin.H{
 			"schedule":                  scheduleBeautified.Schedule,

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 	"unicode"
@@ -71,18 +72,24 @@ func parseMonthParam(c *gin.Context) time.Time {
 	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 }
 
+func buildMiaroURL(team int, month string) string {
+	params := []string{}
+	if month != "" {
+		params = append(params, fmt.Sprintf("month=%s", month))
+	}
+	if team > pkg.MiaroTeam {
+		params = append(params, fmt.Sprintf("team=%d", team))
+	}
+	if len(params) > 0 {
+		return "/miaro?" + strings.Join(params, "&")
+	}
+	return "/miaro"
+}
+
 func renderSchedule(c *gin.Context, team int) {
 	schedule := pkg.CalculateSchedule(time.Now(), team)
 	targetMonth := parseMonthParam(c)
 	scheduleBeautified := pkg.FormatScheduleBeautified(schedule, targetMonth)
-
-	// Build full month nav URLs preserving team param
-	prevMonthURL := fmt.Sprintf("/miaro?month=%s", scheduleBeautified.PrevMonth)
-	nextMonthURL := fmt.Sprintf("/miaro?month=%s", scheduleBeautified.NextMonth)
-	if team > 1 {
-		prevMonthURL = fmt.Sprintf("/miaro?month=%s&team=%d", scheduleBeautified.PrevMonth, team)
-		nextMonthURL = fmt.Sprintf("/miaro?month=%s&team=%d", scheduleBeautified.NextMonth, team)
-	}
 
 	c.HTML(http.StatusOK, "miaroSchedule.tmpl", gin.H{
 		"Schedule":               scheduleBeautified.Schedule,
@@ -91,8 +98,8 @@ func renderSchedule(c *gin.Context, team int) {
 		"ScheduleNextWorkingDay": scheduleBeautified.ScheduleNextWorkingDay,
 		"CalendarDays":           scheduleBeautified.CalendarDays,
 		"CalendarMonthLabel":     scheduleBeautified.CalendarMonthLabel,
-		"PrevMonthURL":           template.URL(prevMonthURL),
-		"NextMonthURL":           template.URL(nextMonthURL),
+		"PrevMonthURL":           template.URL(buildMiaroURL(team, scheduleBeautified.PrevMonth)),
+		"NextMonthURL":           template.URL(buildMiaroURL(team, scheduleBeautified.NextMonth)),
 		"IsCurrentMonth":         scheduleBeautified.IsCurrentMonth,
 		"Team":                   team,
 		"Teams":                  pkg.BuildTeamList(team),
@@ -108,11 +115,7 @@ func SchedulerHandler() gin.HandlerFunc {
 		// Canonicalize: ?team=1 -> redirect to /miaro (preserve month)
 		if hasValidParam && teamParam == pkg.MiaroTeam {
 			setTeamCookie(c, pkg.MiaroTeam)
-			redirect := "/miaro"
-			if m := c.Query("month"); m != "" {
-				redirect = fmt.Sprintf("/miaro?month=%s", m)
-			}
-			c.Redirect(http.StatusFound, redirect)
+			c.Redirect(http.StatusFound, buildMiaroURL(pkg.MiaroTeam, c.Query("month")))
 			return
 		}
 
@@ -125,11 +128,7 @@ func SchedulerHandler() gin.HandlerFunc {
 
 		// No valid param — check cookie (preserve month)
 		if hasValidCookie && teamCookie != pkg.MiaroTeam {
-			redirect := fmt.Sprintf("/miaro?team=%d", teamCookie)
-			if m := c.Query("month"); m != "" {
-				redirect = fmt.Sprintf("/miaro?team=%d&month=%s", teamCookie, m)
-			}
-			c.Redirect(http.StatusFound, redirect)
+			c.Redirect(http.StatusFound, buildMiaroURL(teamCookie, c.Query("month")))
 			return
 		}
 
@@ -148,15 +147,13 @@ func SchedulerJSONHandler() gin.HandlerFunc {
 		}
 
 		schedule := pkg.CalculateSchedule(time.Now(), team)
-		now := time.Now().In(pkg.ParisLoc())
-		currentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-		scheduleBeautified := pkg.FormatScheduleBeautified(schedule, currentMonth)
+		scheduleText := pkg.FormatScheduleText(schedule)
 
 		c.JSON(http.StatusOK, gin.H{
-			"schedule":                  scheduleBeautified.Schedule,
-			"is_working":                scheduleBeautified.IsWorking,
-			"next_working_day":          scheduleBeautified.NextWorkingDay,
-			"schedule_next_working_day": scheduleBeautified.ScheduleNextWorkingDay,
+			"schedule":                  scheduleText.Schedule,
+			"is_working":                scheduleText.IsWorking,
+			"next_working_day":          scheduleText.NextWorkingDay,
+			"schedule_next_working_day": scheduleText.ScheduleNextWorkingDay,
 			"raw_schedule":              schedule,
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -339,11 +339,9 @@ func TestSchedulerHandler_MonthParam(t *testing.T) {
 		t.Errorf("Expected status 200, got %d", w.Code)
 	}
 
-	// Template outputs CalendarMonthLabel once it's wired (Task 3).
-	// For now, verify the page renders successfully.
 	body := w.Body.String()
-	if len(body) == 0 {
-		t.Error("Expected non-empty HTML response for month=2026-04")
+	if !strings.Contains(body, "Avril 2026") {
+		t.Error("Expected response to contain 'Avril 2026' for month=2026-04")
 	}
 }
 
@@ -370,11 +368,9 @@ func TestSchedulerHandler_MonthAndTeamParams(t *testing.T) {
 		t.Errorf("Expected status 200, got %d", w.Code)
 	}
 
-	// Template outputs CalendarMonthLabel once it's wired (Task 3).
-	// For now, verify the page renders and the team cookie is set.
 	body := w.Body.String()
-	if len(body) == 0 {
-		t.Error("Expected non-empty HTML response for month=2026-05&team=3")
+	if !strings.Contains(body, "Mai 2026") {
+		t.Error("Expected response to contain 'Mai 2026' for month=2026-05")
 	}
 
 	cookies := w.Result().Cookies()

--- a/main_test.go
+++ b/main_test.go
@@ -87,7 +87,6 @@ func TestSchedulerHandler(t *testing.T) {
 		"<!DOCTYPE html>",
 		"Horaire de Miaro",
 		"Statut",
-		"Planning du mois",
 	}
 
 	for _, expected := range expectedStrings {
@@ -326,6 +325,67 @@ func TestSchedulerJSONHandler_DefaultTeam(t *testing.T) {
 	team := rawSchedule["team"].(float64)
 	if int(team) != 1 {
 		t.Errorf("Expected team 1 in raw_schedule, got %v", team)
+	}
+}
+
+func TestSchedulerHandler_MonthParam(t *testing.T) {
+	router := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?month=2026-04", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	// Template outputs CalendarMonthLabel once it's wired (Task 3).
+	// For now, verify the page renders successfully.
+	body := w.Body.String()
+	if len(body) == 0 {
+		t.Error("Expected non-empty HTML response for month=2026-04")
+	}
+}
+
+func TestSchedulerHandler_InvalidMonthDefaultsToCurrent(t *testing.T) {
+	router := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?month=invalid", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestSchedulerHandler_MonthAndTeamParams(t *testing.T) {
+	router := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?month=2026-05&team=3", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	// Template outputs CalendarMonthLabel once it's wired (Task 3).
+	// For now, verify the page renders and the team cookie is set.
+	body := w.Body.String()
+	if len(body) == 0 {
+		t.Error("Expected non-empty HTML response for month=2026-05&team=3")
+	}
+
+	cookies := w.Result().Cookies()
+	var teamCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "miaro-team" {
+			teamCookie = c
+		}
+	}
+	if teamCookie == nil {
+		t.Fatal("Expected miaro-team cookie to be set")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -388,4 +388,3 @@ func TestSchedulerHandler_MonthAndTeamParams(t *testing.T) {
 		t.Fatal("Expected miaro-team cookie to be set")
 	}
 }
-

--- a/pkg/schedulerService.go
+++ b/pkg/schedulerService.go
@@ -45,6 +45,11 @@ type Schedule struct {
 	Team          int          `json:"team"`
 }
 
+// ParisLoc returns the Europe/Paris timezone location.
+func ParisLoc() *time.Location {
+	return parisLoc
+}
+
 // CalculateSchedule computes the shift for the given date and team.
 // Each team's epoch is offset forward by (team-1)*2 days from the base epoch (Aug 31, 2024).
 // Invalid team numbers are clamped to MiaroTeam (team 1).

--- a/pkg/template.go
+++ b/pkg/template.go
@@ -43,9 +43,27 @@ var frenchMonths = map[time.Month]string{
 	time.December:  "Décembre",
 }
 
-// FormatScheduleBeautified converts a Schedule into human-readable French text.
-// It determines the current shift type, whether the person is currently working,
-// and when the next working day will be.
+// ScheduleText contains the text-only fields from ScheduleBeautified (no calendar data).
+type ScheduleText struct {
+	Schedule               string
+	IsWorking              string
+	ScheduleNextWorkingDay string
+	NextWorkingDay         string
+}
+
+// FormatScheduleText returns French text for the schedule without generating calendar data.
+func FormatScheduleText(schedule Schedule) ScheduleText {
+	scheduleNextWorkingDay, nextWorkingDay, _ := nextWorkingDay(schedule.DayInSchedule)
+	return ScheduleText{
+		Schedule:               getBeautifiedSchedule(schedule.ScheduleType),
+		IsWorking:              isWorkingString(schedule),
+		ScheduleNextWorkingDay: scheduleNextWorkingDay,
+		NextWorkingDay:         nextWorkingDay,
+	}
+}
+
+// FormatScheduleBeautified converts a Schedule into human-readable French text
+// with full calendar data for the target month.
 func FormatScheduleBeautified(schedule Schedule, targetMonth time.Time) ScheduleBeautified {
 	currentDay := getBeautifiedSchedule(schedule.ScheduleType)
 	isWorking := isWorkingString(schedule)

--- a/pkg/template.go
+++ b/pkg/template.go
@@ -7,34 +7,57 @@ import (
 
 // ScheduleBeautified contains human-readable French text representations of the schedule information.
 type ScheduleBeautified struct {
-	Schedule               string       // e.g., "du matin", "de l'après-midi", "de nuit", "libre"
-	IsWorking              string       // e.g., "est au travail", "n'est pas au travail"
-	ScheduleNextWorkingDay string       // e.g., "du matin" (for the next working day)
-	NextWorkingDay         string       // e.g., "demain", "dans 3 jours"
+	Schedule               string        // e.g., "du matin", "de l'après-midi", "de nuit", "libre"
+	IsWorking              string        // e.g., "est au travail", "n'est pas au travail"
+	ScheduleNextWorkingDay string        // e.g., "du matin" (for the next working day)
+	NextWorkingDay         string        // e.g., "demain", "dans 3 jours"
 	CalendarDays           []CalendarDay // Calendar data for the month
+	CalendarMonthLabel     string        // e.g., "Mars 2026"
+	PrevMonth              string        // e.g., "2026-02" for prev link
+	NextMonth              string        // e.g., "2026-04" for next link
+	IsCurrentMonth         bool          // True when viewing current month
 }
 
 // CalendarDay represents a single day in the calendar view
 type CalendarDay struct {
-	DayNumber     int    // Day of the month (1-31)
-	ShiftType     string // "Matin", "Après-midi", "Nuit", "Libre"
-	IsToday       bool   // True if this is today
-	IsNextWork    bool   // True if this is the next working day
-	IsEmpty       bool   // True for empty cells at start/end of month
-	ShiftClass    string // CSS class: "morning", "afternoon", "night", "free"
+	DayNumber    int    // Day of the month (1-31)
+	ShiftType    string // "Matin", "Après-midi", "Nuit", "Libre"
+	IsToday      bool   // True if this is today
+	IsNextWork   bool   // True if this is the next working day
+	IsOtherMonth bool   // True for days from adjacent months
+	ShiftClass   string // CSS class: "morning", "afternoon", "night", "free"
+}
+
+var frenchMonths = map[time.Month]string{
+	time.January:   "Janvier",
+	time.February:  "Février",
+	time.March:     "Mars",
+	time.April:     "Avril",
+	time.May:       "Mai",
+	time.June:      "Juin",
+	time.July:      "Juillet",
+	time.August:    "Août",
+	time.September: "Septembre",
+	time.October:   "Octobre",
+	time.November:  "Novembre",
+	time.December:  "Décembre",
 }
 
 // FormatScheduleBeautified converts a Schedule into human-readable French text.
 // It determines the current shift type, whether the person is currently working,
 // and when the next working day will be.
-func FormatScheduleBeautified(schedule Schedule) ScheduleBeautified {
+func FormatScheduleBeautified(schedule Schedule, targetMonth time.Time) ScheduleBeautified {
 	currentDay := getBeautifiedSchedule(schedule.ScheduleType)
-
 	isWorking := isWorkingString(schedule)
-
 	scheduleNextWorkingDay, nextWorkingDay, nextWorkDays := nextWorkingDay(schedule.DayInSchedule)
 
-	calendarDays := GenerateCalendarData(schedule, nextWorkDays)
+	calendarDays := GenerateCalendarData(schedule, targetMonth, nextWorkDays)
+
+	now := schedule.TimeRequested.In(parisLoc)
+	year, month, _ := targetMonth.In(parisLoc).Date()
+
+	prevMonth := targetMonth.AddDate(0, -1, 0)
+	nextMonthDate := targetMonth.AddDate(0, 1, 0)
 
 	return ScheduleBeautified{
 		Schedule:               currentDay,
@@ -42,6 +65,10 @@ func FormatScheduleBeautified(schedule Schedule) ScheduleBeautified {
 		ScheduleNextWorkingDay: scheduleNextWorkingDay,
 		NextWorkingDay:         nextWorkingDay,
 		CalendarDays:           calendarDays,
+		CalendarMonthLabel:     fmt.Sprintf("%s %d", frenchMonths[month], year),
+		PrevMonth:              prevMonth.Format("2006-01"),
+		NextMonth:              nextMonthDate.Format("2006-01"),
+		IsCurrentMonth:         now.Year() == year && now.Month() == month,
 	}
 }
 
@@ -101,16 +128,19 @@ func nextWorkingDay(day int) (string, string, int) {
 	return getBeautifiedSchedule(schedule[(day+i)%10]), nextWorkingDayStr, i
 }
 
-// GenerateCalendarData generates calendar data for the current month
-func GenerateCalendarData(currentSchedule Schedule, nextWorkDays int) []CalendarDay {
+// GenerateCalendarData generates calendar data for the target month with full-week grids.
+// Leading and trailing days from adjacent months are included to complete each row.
+func GenerateCalendarData(currentSchedule Schedule, targetMonth time.Time, nextWorkDays int) []CalendarDay {
 	now := currentSchedule.TimeRequested.In(parisLoc)
+	targetMonth = targetMonth.In(parisLoc)
 
-	// Get first and last day of current month
-	year, month, _ := now.Date()
+	year, month, _ := targetMonth.Date()
 	firstDay := time.Date(year, month, 1, 0, 0, 0, 0, parisLoc)
 	lastDay := firstDay.AddDate(0, 1, -1)
 
-	// Calculate weekday offset (Monday = 0, Sunday = 6)
+	isCurrentMonth := now.Year() == year && now.Month() == month
+
+	// Monday = 0, Sunday = 6
 	weekdayOffset := int(firstDay.Weekday()) - 1
 	if weekdayOffset == -1 {
 		weekdayOffset = 6
@@ -118,46 +148,65 @@ func GenerateCalendarData(currentSchedule Schedule, nextWorkDays int) []Calendar
 
 	var calendarDays []CalendarDay
 
-	// Add empty cells for days before month starts
-	for i := 0; i < weekdayOffset; i++ {
-		calendarDays = append(calendarDays, CalendarDay{IsEmpty: true})
+	// Leading days from previous month
+	for i := weekdayOffset; i > 0; i-- {
+		d := firstDay.AddDate(0, 0, -i)
+		calendarDays = append(calendarDays, buildCalendarDay(d, currentSchedule.Team, now, isCurrentMonth, nextWorkDays, true))
 	}
 
-	// Add actual days of the month
+	// Days of the target month
 	for day := 1; day <= lastDay.Day(); day++ {
-		currentDate := time.Date(year, month, day, 12, 0, 0, 0, parisLoc)
-		daySchedule := CalculateSchedule(currentDate, currentSchedule.Team)
+		d := time.Date(year, month, day, 12, 0, 0, 0, parisLoc)
+		calendarDays = append(calendarDays, buildCalendarDay(d, currentSchedule.Team, now, isCurrentMonth, nextWorkDays, false))
+	}
 
-		isToday := day == now.Day()
-		isNextWork := !isToday && daySchedule.ScheduleType != FREE &&
-			(currentDate.After(now) || currentDate.Equal(now)) &&
-			day == now.Day()+nextWorkDays
-
-		var shiftType, shiftClass string
-		switch daySchedule.ScheduleType {
-		case MORNING:
-			shiftType = "Matin"
-			shiftClass = "morning"
-		case AFTERNOON:
-			shiftType = "Après-midi"
-			shiftClass = "afternoon"
-		case NIGHT:
-			shiftType = "Nuit"
-			shiftClass = "night"
-		case FREE:
-			shiftType = "Libre"
-			shiftClass = "free"
+	// Trailing days from next month
+	trailingDays := 7 - (len(calendarDays) % 7)
+	if trailingDays < 7 {
+		for i := 1; i <= trailingDays; i++ {
+			d := lastDay.AddDate(0, 0, i)
+			calendarDays = append(calendarDays, buildCalendarDay(d, currentSchedule.Team, now, isCurrentMonth, nextWorkDays, true))
 		}
-
-		calendarDays = append(calendarDays, CalendarDay{
-			DayNumber:  day,
-			ShiftType:  shiftType,
-			IsToday:    isToday,
-			IsNextWork: isNextWork,
-			IsEmpty:    false,
-			ShiftClass: shiftClass,
-		})
 	}
 
 	return calendarDays
+}
+
+func buildCalendarDay(date time.Time, team int, now time.Time, isCurrentMonth bool, nextWorkDays int, isOtherMonth bool) CalendarDay {
+	daySchedule := CalculateSchedule(date, team)
+	_, _, day := date.Date()
+
+	isToday := false
+	isNextWork := false
+	if isCurrentMonth && !isOtherMonth {
+		isToday = day == now.Day()
+		isNextWork = !isToday && daySchedule.ScheduleType != FREE &&
+			(date.After(now) || date.Equal(now)) &&
+			day == now.Day()+nextWorkDays
+	}
+
+	var shiftType, shiftClass string
+	switch daySchedule.ScheduleType {
+	case MORNING:
+		shiftType = "Matin"
+		shiftClass = "morning"
+	case AFTERNOON:
+		shiftType = "Après-midi"
+		shiftClass = "afternoon"
+	case NIGHT:
+		shiftType = "Nuit"
+		shiftClass = "night"
+	case FREE:
+		shiftType = "Libre"
+		shiftClass = "free"
+	}
+
+	return CalendarDay{
+		DayNumber:    day,
+		ShiftType:    shiftType,
+		IsToday:      isToday,
+		IsNextWork:   isNextWork,
+		IsOtherMonth: isOtherMonth,
+		ShiftClass:   shiftClass,
+	}
 }

--- a/pkg/template_test.go
+++ b/pkg/template_test.go
@@ -229,6 +229,52 @@ func TestNextWorkingDay(t *testing.T) {
 
 }
 
+func TestGenerateCalendarData_FullWeeks(t *testing.T) {
+	// March 2026: starts on Sunday (weekdayOffset=6), ends on Tuesday (Mar 31)
+	// 6 leading days (Feb 23 Mon - Feb 28 Sat) + 31 March days + 5 trailing days (Apr 1-5) = 42 (6 weeks)
+	now := time.Date(2026, time.March, 15, 12, 0, 0, 0, parisLoc)
+	targetMonth := time.Date(2026, time.March, 1, 0, 0, 0, 0, parisLoc)
+	schedule := CalculateSchedule(now, MiaroTeam)
+
+	days := GenerateCalendarData(schedule, targetMonth, 1)
+
+	// Grid should be 6 weeks * 7 = 42 days
+	assert.Equal(t, 42, len(days))
+
+	// First day should be Monday Feb 23 (other-month)
+	assert.Equal(t, 23, days[0].DayNumber)
+	assert.Equal(t, true, days[0].IsOtherMonth)
+	assert.NotEqual(t, "", days[0].ShiftClass)
+
+	// 7th day should be Sunday March 1 (this month)
+	assert.Equal(t, 1, days[6].DayNumber)
+	assert.Equal(t, false, days[6].IsOtherMonth)
+
+	// Day 15 should be marked as today
+	// 6 leading days + 14 (March 1 is at index 6, so March 15 is at index 6+14=20)
+	assert.Equal(t, 15, days[20].DayNumber)
+	assert.Equal(t, true, days[20].IsToday)
+
+	// Last day should be Sunday Apr 5 (other-month)
+	assert.Equal(t, 5, days[41].DayNumber)
+	assert.Equal(t, true, days[41].IsOtherMonth)
+}
+
+func TestGenerateCalendarData_OtherMonthNoToday(t *testing.T) {
+	// Viewing April 2026 while today is March 15 -- no day should be IsToday
+	now := time.Date(2026, time.March, 15, 12, 0, 0, 0, parisLoc)
+	targetMonth := time.Date(2026, time.April, 1, 0, 0, 0, 0, parisLoc)
+	schedule := CalculateSchedule(now, MiaroTeam)
+
+	days := GenerateCalendarData(schedule, targetMonth, 1)
+
+	for _, day := range days {
+		if day.IsToday {
+			t.Errorf("No day should be IsToday when viewing a different month, but day %d is", day.DayNumber)
+		}
+	}
+}
+
 func TestCalculateSchedule_UsesParisTimezone(t *testing.T) {
 	utc := time.Date(2025, 6, 9, 13, 30, 0, 0, time.UTC)
 

--- a/templates/miaroSchedule.tmpl
+++ b/templates/miaroSchedule.tmpl
@@ -83,6 +83,19 @@
             box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
         }
 
+        body.theme-neumorphism .calendar-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+        body.theme-neumorphism .calendar-nav h2 { font-size: 1.125rem; font-weight: 700; }
+        body.theme-neumorphism .calendar-nav a {
+            width: 36px; height: 36px; display: flex; align-items: center; justify-content: center;
+            border-radius: 50%; color: var(--text); text-decoration: none; font-size: 1.125rem;
+            background: var(--bg);
+            box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+            transition: all 0.2s;
+        }
+        body.theme-neumorphism .calendar-nav a:hover {
+            box-shadow: 1px 1px 3px var(--shadow-dark), -1px -1px 3px var(--shadow-light);
+        }
+
         body.theme-neumorphism .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 0.625rem; }
         body.theme-neumorphism .calendar-day-header {
             font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em;
@@ -94,14 +107,14 @@
             background: var(--bg);
             box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
         }
-        body.theme-neumorphism .calendar-day:not(.empty):hover {
+        body.theme-neumorphism .calendar-day:hover {
             box-shadow: 2px 2px 4px var(--shadow-dark), -2px -2px 4px var(--shadow-light);
         }
-        body.theme-neumorphism .calendar-day.empty { box-shadow: none; background: transparent; }
         body.theme-neumorphism .calendar-day.morning { background: rgba(246, 173, 85, 0.15); }
         body.theme-neumorphism .calendar-day.afternoon { background: rgba(66, 153, 225, 0.15); }
         body.theme-neumorphism .calendar-day.night { background: rgba(159, 122, 234, 0.15); }
         body.theme-neumorphism .calendar-day.free { background: rgba(72, 187, 120, 0.1); }
+        body.theme-neumorphism .calendar-day.other-month { opacity: 0.35; pointer-events: none; }
         body.theme-neumorphism .calendar-day.today {
             background: var(--text); color: white;
             box-shadow: 4px 4px 12px rgba(45, 55, 72, 0.3), -4px -4px 8px var(--shadow-light);
@@ -193,18 +206,27 @@
         body.theme-bento .calendar-title h2 { font-size: 1rem; font-weight: 600; }
         body.theme-bento .next-badge { background: var(--accent); color: white; padding: 0.375rem 0.875rem; border-radius: 20px; font-size: 0.75rem; font-weight: 500; }
 
+        body.theme-bento .calendar-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+        body.theme-bento .calendar-nav h2 { font-size: 1rem; font-weight: 600; }
+        body.theme-bento .calendar-nav a {
+            width: 32px; height: 32px; display: flex; align-items: center; justify-content: center;
+            border-radius: 10px; color: var(--text); text-decoration: none; font-size: 1rem;
+            background: var(--bg); border: 1px solid var(--border); transition: all 0.15s;
+        }
+        body.theme-bento .calendar-nav a:hover { background: #e2e8f0; }
+
         body.theme-bento .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 0.5rem; }
         body.theme-bento .calendar-header { font-size: 0.6875rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); text-align: center; padding: 0.5rem; }
         body.theme-bento .calendar-day {
             aspect-ratio: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
             border-radius: 12px; background: var(--bg); font-size: 0.875rem; transition: all 0.15s ease;
         }
-        body.theme-bento .calendar-day:not(.empty):hover { background: #e2e8f0; }
-        body.theme-bento .calendar-day.empty { background: transparent; }
+        body.theme-bento .calendar-day:hover { background: #e2e8f0; }
         body.theme-bento .calendar-day.morning { background: rgba(249, 115, 22, 0.12); }
         body.theme-bento .calendar-day.afternoon { background: rgba(14, 165, 233, 0.12); }
         body.theme-bento .calendar-day.night { background: rgba(139, 92, 246, 0.12); }
         body.theme-bento .calendar-day.free { background: rgba(34, 197, 94, 0.08); }
+        body.theme-bento .calendar-day.other-month { opacity: 0.35; pointer-events: none; }
         body.theme-bento .calendar-day.today { background: var(--text); color: white; font-weight: 700; }
         body.theme-bento .calendar-day.next-work { background: var(--accent); color: white; font-weight: 700; box-shadow: 0 4px 16px rgba(99, 102, 241, 0.3); }
         body.theme-bento .day-number { font-weight: 600; }
@@ -282,18 +304,23 @@
         body.theme-terminal .section { margin: 1.5rem 0; padding: 1rem; background: var(--bg); border-radius: 6px; border: 1px solid var(--border); }
         body.theme-terminal .section-title { color: var(--cyan); margin-bottom: 0.75rem; font-weight: 600; }
 
+        body.theme-terminal .calendar-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+        body.theme-terminal .calendar-nav span { color: var(--cyan); font-weight: 600; }
+        body.theme-terminal .calendar-nav a { color: var(--green); text-decoration: none; font-size: 0.875rem; }
+        body.theme-terminal .calendar-nav a:hover { text-decoration: underline; }
+
         body.theme-terminal .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-top: 0.5rem; }
         body.theme-terminal .calendar-header { color: var(--text-muted); text-align: center; padding: 0.5rem 0; font-size: 0.6875rem; }
         body.theme-terminal .calendar-day {
             aspect-ratio: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
             background: var(--bg); border: 1px solid var(--border); font-size: 0.75rem; transition: all 0.15s;
         }
-        body.theme-terminal .calendar-day:not(.empty):hover { border-color: var(--cyan); }
-        body.theme-terminal .calendar-day.empty { background: transparent; border-color: transparent; }
+        body.theme-terminal .calendar-day:hover { border-color: var(--cyan); }
         body.theme-terminal .calendar-day.morning { border-color: var(--yellow); background: rgba(210, 153, 34, 0.15); }
         body.theme-terminal .calendar-day.afternoon { border-color: var(--blue); background: rgba(88, 166, 255, 0.15); }
         body.theme-terminal .calendar-day.night { border-color: var(--purple); background: rgba(163, 113, 247, 0.15); }
         body.theme-terminal .calendar-day.free { border-color: var(--green); background: rgba(63, 185, 80, 0.08); }
+        body.theme-terminal .calendar-day.other-month { opacity: 0.3; pointer-events: none; }
         body.theme-terminal .calendar-day.today { background: var(--green); color: var(--bg); border-color: var(--green); font-weight: 700; }
         body.theme-terminal .calendar-day.next-work { background: var(--cyan); color: var(--bg); border-color: var(--cyan); font-weight: 700; }
         body.theme-terminal .day-number { font-weight: 600; }
@@ -587,9 +614,10 @@
             </div>
 
             <div class="calendar-card neu">
-                <div class="calendar-header">
-                    <h2>Planning du mois</h2>
-                    <span class="next-badge">Prochain: {{ if eq .NextWorkingDay "demain" }}Demain{{ else }}{{ .NextWorkingDay | title }}{{ end }}</span>
+                <div class="calendar-nav">
+                    <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">&larr;</a>
+                    <h2>{{ .CalendarMonthLabel }}</h2>
+                    <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">&rarr;</a>
                 </div>
                 <div class="calendar-grid">
                     <div class="calendar-day-header">Lun</div>
@@ -600,10 +628,12 @@
                     <div class="calendar-day-header">Sam</div>
                     <div class="calendar-day-header">Dim</div>
                     {{ range .CalendarDays }}
-                    <div class="calendar-day {{ .ShiftClass }} {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
-                        {{ if not .IsEmpty }}
+                    <div class="calendar-day {{ .ShiftClass }} {{ if .IsOtherMonth }}other-month{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+                        {{ if not .IsOtherMonth }}
                         <div class="day-number">{{ .DayNumber }}</div>
                         <div class="shift-indicator">{{ .ShiftType }}</div>
+                        {{ else }}
+                        <div class="day-number">{{ .DayNumber }}</div>
                         {{ end }}
                     </div>
                     {{ end }}
@@ -677,9 +707,10 @@
                 </div>
 
                 <div class="bento-item bento-calendar">
-                    <div class="calendar-title">
-                        <h2>Planning du mois</h2>
-                        <span class="next-badge">Prochain: {{ if eq .NextWorkingDay "demain" }}Demain{{ else }}{{ .NextWorkingDay | title }}{{ end }}</span>
+                    <div class="calendar-nav">
+                        <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">&larr;</a>
+                        <h2>{{ .CalendarMonthLabel }}</h2>
+                        <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">&rarr;</a>
                     </div>
                     <div class="calendar-grid">
                         <div class="calendar-header">Lun</div>
@@ -690,10 +721,12 @@
                         <div class="calendar-header">Sam</div>
                         <div class="calendar-header">Dim</div>
                         {{ range .CalendarDays }}
-                        <div class="calendar-day {{ .ShiftClass }} {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
-                            {{ if not .IsEmpty }}
+                        <div class="calendar-day {{ .ShiftClass }} {{ if .IsOtherMonth }}other-month{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+                            {{ if not .IsOtherMonth }}
                             <div class="day-number">{{ .DayNumber }}</div>
                             <div class="shift-indicator">{{ .ShiftType }}</div>
+                            {{ else }}
+                            <div class="day-number">{{ .DayNumber }}</div>
                             {{ end }}
                         </div>
                         {{ end }}
@@ -781,7 +814,11 @@
                 </div>
 
                 <div class="section">
-                    <div class="section-title">$ cal --schedule</div>
+                    <div class="calendar-nav">
+                        <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">[prev]</a>
+                        <span>$ cal --schedule {{ .CalendarMonthLabel }}</span>
+                        <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">[next]</a>
+                    </div>
                     <div class="calendar-grid">
                         <div class="calendar-header">LUN</div>
                         <div class="calendar-header">MAR</div>
@@ -791,10 +828,12 @@
                         <div class="calendar-header">SAM</div>
                         <div class="calendar-header">DIM</div>
                         {{ range .CalendarDays }}
-                        <div class="calendar-day {{ .ShiftClass }} {{ if .IsEmpty }}empty{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
-                            {{ if not .IsEmpty }}
+                        <div class="calendar-day {{ .ShiftClass }} {{ if .IsOtherMonth }}other-month{{ end }} {{ if .IsToday }}today{{ end }} {{ if .IsNextWork }}next-work{{ end }}">
+                            {{ if not .IsOtherMonth }}
                             <div class="day-number">{{ .DayNumber }}</div>
                             <div class="shift-indicator">{{ .ShiftType }}</div>
+                            {{ else }}
+                            <div class="day-number">{{ .DayNumber }}</div>
                             {{ end }}
                         </div>
                         {{ end }}
@@ -861,7 +900,13 @@
 
             // Team selector
             window.selectTeam = function(teamNum) {
-                window.location.href = '/miaro?team=' + teamNum;
+                const url = new URL(window.location);
+                if (teamNum === '1' || teamNum === 1) {
+                    url.searchParams.delete('team');
+                } else {
+                    url.searchParams.set('team', teamNum);
+                }
+                window.location.href = url.pathname + '?' + url.searchParams.toString();
             };
         })();
     </script>

--- a/templates/miaroSchedule.tmpl
+++ b/templates/miaroSchedule.tmpl
@@ -615,9 +615,9 @@
 
             <div class="calendar-card neu">
                 <div class="calendar-nav">
-                    <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">&larr;</a>
+                    <a href="{{ .PrevMonthURL }}">&larr;</a>
                     <h2>{{ .CalendarMonthLabel }}</h2>
-                    <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">&rarr;</a>
+                    <a href="{{ .NextMonthURL }}">&rarr;</a>
                 </div>
                 <div class="calendar-grid">
                     <div class="calendar-day-header">Lun</div>
@@ -708,9 +708,9 @@
 
                 <div class="bento-item bento-calendar">
                     <div class="calendar-nav">
-                        <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">&larr;</a>
+                        <a href="{{ .PrevMonthURL }}">&larr;</a>
                         <h2>{{ .CalendarMonthLabel }}</h2>
-                        <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">&rarr;</a>
+                        <a href="{{ .NextMonthURL }}">&rarr;</a>
                     </div>
                     <div class="calendar-grid">
                         <div class="calendar-header">Lun</div>
@@ -815,9 +815,9 @@
 
                 <div class="section">
                     <div class="calendar-nav">
-                        <a href="/miaro?month={{ .PrevMonth }}{{ .MonthQuery }}">[prev]</a>
+                        <a href="{{ .PrevMonthURL }}">[prev]</a>
                         <span>$ cal --schedule {{ .CalendarMonthLabel }}</span>
-                        <a href="/miaro?month={{ .NextMonth }}{{ .MonthQuery }}">[next]</a>
+                        <a href="{{ .NextMonthURL }}">[next]</a>
                     </div>
                     <div class="calendar-grid">
                         <div class="calendar-header">LUN</div>


### PR DESCRIPTION
## Summary
- Add `?month=YYYY-MM` query param to browse past/future months
- Calendar now shows full weeks with adjacent-month days greyed out (replacing empty cells)
- Prev/next navigation arrows in all 3 themes (neumorphism, bento, terminal)
- Team param preserved across month navigation and redirects
- French month labels (e.g. "Mars 2026")

## Test plan
- [x] Unit tests for full-week grid generation (leading/trailing days)
- [x] Unit tests for month param parsing (valid, invalid, missing)
- [x] Unit tests for team + month param combination
- [x] Playwright visual tests across all 3 themes + mobile viewport
- [x] Verified nav links render correct URLs with team preservation