### PR TITLE
fix: correct MiaroTeam to equipe 3 and fix team switching bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func buildMiaroURL(team int, month string) string {
 	if month != "" {
 		params = append(params, fmt.Sprintf("month=%s", month))
 	}
-	if team > pkg.MiaroTeam {
+	if team != pkg.MiaroTeam {
 		params = append(params, fmt.Sprintf("team=%d", team))
 	}
 	if len(params) > 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -195,7 +195,7 @@ func TestSchedulerHandler_TeamFromQueryParam(t *testing.T) {
 	router := setupTestRouter()
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/miaro?team=3", nil)
+	req, _ := http.NewRequest("GET", "/miaro?team=2", nil)
 	router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
@@ -213,16 +213,16 @@ func TestSchedulerHandler_TeamFromQueryParam(t *testing.T) {
 	if teamCookie == nil {
 		t.Fatal("Expected miaro-team cookie to be set")
 	}
-	if teamCookie.Value != "3" {
-		t.Errorf("Expected cookie value '3', got '%s'", teamCookie.Value)
+	if teamCookie.Value != "2" {
+		t.Errorf("Expected cookie value '2', got '%s'", teamCookie.Value)
 	}
 }
 
-func TestSchedulerHandler_Team1RedirectsToCleanURL(t *testing.T) {
+func TestSchedulerHandler_MiaroTeamRedirectsToCleanURL(t *testing.T) {
 	router := setupTestRouter()
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/miaro?team=1", nil)
+	req, _ := http.NewRequest("GET", "/miaro?team=3", nil)
 	router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusFound {
@@ -249,20 +249,20 @@ func TestSchedulerHandler_CookieRedirect(t *testing.T) {
 	}
 }
 
-func TestSchedulerHandler_CookieTeam1NoRedirect(t *testing.T) {
+func TestSchedulerHandler_CookieMiaroTeamNoRedirect(t *testing.T) {
 	router := setupTestRouter()
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/miaro", nil)
-	req.AddCookie(&http.Cookie{Name: "miaro-team", Value: "1"})
+	req.AddCookie(&http.Cookie{Name: "miaro-team", Value: "3"})
 	router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200 (no redirect for team 1 cookie), got %d", w.Code)
+		t.Errorf("Expected status 200 (no redirect for MiaroTeam cookie), got %d", w.Code)
 	}
 }
 
-func TestSchedulerHandler_InvalidTeamDefaultsTo1(t *testing.T) {
+func TestSchedulerHandler_InvalidTeamDefaultsToMiaroTeam(t *testing.T) {
 	router := setupTestRouter()
 
 	w := httptest.NewRecorder()
@@ -271,6 +271,39 @@ func TestSchedulerHandler_InvalidTeamDefaultsTo1(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestSchedulerHandler_SwitchToMiaroTeamWithOldCookie(t *testing.T) {
+	router := setupTestRouter()
+
+	// Simulate: user is on team 4 (cookie=4), clicks MiaroTeam (3)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/miaro?team=3", nil)
+	req.AddCookie(&http.Cookie{Name: "miaro-team", Value: "4"})
+	router.ServeHTTP(w, req)
+
+	// Should redirect to /miaro (canonical URL for MiaroTeam)
+	if w.Code != http.StatusFound {
+		t.Errorf("Expected 302 redirect, got %d", w.Code)
+	}
+	if w.Header().Get("Location") != "/miaro" {
+		t.Errorf("Expected redirect to /miaro, got %s", w.Header().Get("Location"))
+	}
+
+	// Cookie should be updated to MiaroTeam
+	cookies := w.Result().Cookies()
+	var teamCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "miaro-team" {
+			teamCookie = c
+		}
+	}
+	if teamCookie == nil {
+		t.Fatal("Expected miaro-team cookie to be set")
+	}
+	if teamCookie.Value != "3" {
+		t.Errorf("Expected cookie value '3', got '%s'", teamCookie.Value)
 	}
 }
 
@@ -323,8 +356,8 @@ func TestSchedulerJSONHandler_DefaultTeam(t *testing.T) {
 
 	rawSchedule := response["raw_schedule"].(map[string]interface{})
 	team := rawSchedule["team"].(float64)
-	if int(team) != 1 {
-		t.Errorf("Expected team 1 in raw_schedule, got %v", team)
+	if int(team) != pkg.MiaroTeam {
+		t.Errorf("Expected team %d in raw_schedule, got %v", pkg.MiaroTeam, team)
 	}
 }
 
@@ -361,7 +394,7 @@ func TestSchedulerHandler_MonthAndTeamParams(t *testing.T) {
 	router := setupTestRouter()
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/miaro?month=2026-05&team=3", nil)
+	req, _ := http.NewRequest("GET", "/miaro?month=2026-05&team=2", nil)
 	router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {

--- a/pkg/schedulerService.go
+++ b/pkg/schedulerService.go
@@ -52,7 +52,7 @@ func ParisLoc() *time.Location {
 
 // CalculateSchedule computes the shift for the given date and team.
 // Each team's epoch is offset forward by (team-1)*2 days from the base epoch (Aug 31, 2024).
-// Invalid team numbers are clamped to MiaroTeam (team 1).
+// Invalid team numbers are clamped to MiaroTeam.
 func CalculateSchedule(date time.Time, team int) Schedule {
 	date = date.In(parisLoc)
 	team = ValidateTeam(team)

--- a/pkg/schedulerService_test.go
+++ b/pkg/schedulerService_test.go
@@ -129,7 +129,7 @@ func TestCalculateSchedule_SpecificDates(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := CalculateSchedule(tc.date, MiaroTeam)
+			result := CalculateSchedule(tc.date, 1) // team 1 has zero offset from base epoch
 
 			if result.DayInSchedule != tc.expectedDay {
 				t.Errorf("%s: expected day %d, got %d", tc.description, tc.expectedDay, result.DayInSchedule)
@@ -184,7 +184,7 @@ func TestCalculateSchedule_TimezoneConversion(t *testing.T) {
 	// Test that UTC time is properly converted to Paris time
 	utc := time.Date(2024, time.September, 1, 22, 0, 0, 0, time.UTC) // 10 PM UTC
 
-	result := CalculateSchedule(utc, MiaroTeam)
+	result := CalculateSchedule(utc, 1) // team 1 for base epoch tests
 
 	// Verify timezone is Paris
 	if result.TimeRequested.Location().String() != "Europe/Paris" {
@@ -238,14 +238,14 @@ func TestCalculateSchedule_TeamOffset(t *testing.T) {
 	}
 }
 
-func TestCalculateSchedule_InvalidTeamDefaultsTo1(t *testing.T) {
+func TestCalculateSchedule_InvalidTeamDefaultsToMiaroTeam(t *testing.T) {
 	loc, _ := time.LoadLocation("Europe/Paris")
 	date := time.Date(2024, time.September, 2, 12, 0, 0, 0, loc)
 
 	result := CalculateSchedule(date, 0)
-	expected := CalculateSchedule(date, 1)
+	expected := CalculateSchedule(date, MiaroTeam)
 
 	if result.DayInSchedule != expected.DayInSchedule {
-		t.Errorf("invalid team should default to team 1")
+		t.Errorf("invalid team should default to MiaroTeam (%d)", MiaroTeam)
 	}
 }

--- a/pkg/team.go
+++ b/pkg/team.go
@@ -3,7 +3,7 @@ package pkg
 import "fmt"
 
 const (
-	MiaroTeam = 1
+	MiaroTeam = 3
 	TeamCount = 5
 )
 

--- a/pkg/team_test.go
+++ b/pkg/team_test.go
@@ -12,10 +12,10 @@ func TestValidateTeam(t *testing.T) {
 	}{
 		{"valid team 1", 1, 1},
 		{"valid team 5", 5, 5},
-		{"zero defaults to 1", 0, 1},
-		{"negative defaults to 1", -1, 1},
-		{"too high defaults to 1", 6, 1},
-		{"way too high defaults to 1", 100, 1},
+		{"zero defaults to MiaroTeam", 0, MiaroTeam},
+		{"negative defaults to MiaroTeam", -1, MiaroTeam},
+		{"too high defaults to MiaroTeam", 6, MiaroTeam},
+		{"way too high defaults to MiaroTeam", 100, MiaroTeam},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -32,9 +32,9 @@ func TestTeamLabel(t *testing.T) {
 		team     int
 		expected string
 	}{
-		{1, "Équipe 1 (Miaro)"},
+		{1, "Équipe 1"},
 		{2, "Équipe 2"},
-		{3, "Équipe 3"},
+		{3, "Équipe 3 (Miaro)"},
 		{4, "Équipe 4"},
 		{5, "Équipe 5"},
 	}
@@ -59,7 +59,7 @@ func TestBuildTeamList(t *testing.T) {
 	if teams[0].Selected {
 		t.Error("team 1 should not be selected")
 	}
-	if teams[0].Label != "Équipe 1 (Miaro)" {
-		t.Errorf("team 1 label = %q, want 'Équipe 1 (Miaro)'", teams[0].Label)
+	if teams[2].Label != "Équipe 3 (Miaro)" {
+		t.Errorf("team 3 label = %q, want 'Équipe 3 (Miaro)'", teams[2].Label)
 	}
 }

--- a/templates/miaroSchedule.tmpl
+++ b/templates/miaroSchedule.tmpl
@@ -935,12 +935,9 @@
             // Team selector
             window.selectTeam = function(teamNum) {
                 const url = new URL(window.location);
-                if (teamNum === '1' || teamNum === 1) {
-                    url.searchParams.delete('team');
-                } else {
-                    url.searchParams.set('team', teamNum);
-                }
-                window.location.href = url.pathname + '?' + url.searchParams.toString();
+                url.searchParams.set('team', teamNum);
+                const qs = url.searchParams.toString();
+                window.location.href = qs ? url.pathname + '?' + qs : url.pathname;
             };
         })();
     </script>


### PR DESCRIPTION
## Summary
- **MiaroTeam = 3**: Miaro is equipe 3, not 1. Updated constant, labels, URL canonicalization, and `buildMiaroURL` comparison (`>` to `!=`)
- **Team switching bug**: Selecting the default team (MiaroTeam) didn't work when a cookie for another team existed. The JS `selectTeam()` stripped the `?team=` param for the default team, so the server read the stale cookie and redirected back. Fix: JS always sends `?team=N`, server canonicalizes as usual
- Tests updated for MiaroTeam=3, new test `SwitchToMiaroTeamWithOldCookie` reproduces the exact bug

## Test plan
- [x] All 34 unit tests pass
- [x] Playwright E2E: default loads equipe 3, switch to 4, switch back to 3, cycle all 5 teams (15 assertions, all pass)